### PR TITLE
Allow build to work with Singularity 3.5.2

### DIFF
--- a/Singularity-GUI
+++ b/Singularity-GUI
@@ -21,7 +21,7 @@ From: ubuntu:18.04
     # Avoid environment import as directory is probably unavailable inside container
     unset XDG_RUNTIME_DIR
 
-%post -c /bin/bash
+%post
 
     apt-get update && apt-get upgrade -y
 

--- a/Singularity-headless
+++ b/Singularity-headless
@@ -16,7 +16,7 @@ From: ubuntu:18.04
     export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/netCDFLFRicReader
     export PV_PLUGIN_PATH=/usr/local/lib/netCDFLFRicReader
 
-%post -c /bin/bash
+%post
 
     apt-get update && apt-get upgrade -y
 


### PR DESCRIPTION
Singularity 3.5.2 doesn't work with the `-c` option. (The issue was [fixed in 3.5.3](https://github.com/sylabs/singularity/releases/tag/v3.5.3).) This PR allows the build to work for either.